### PR TITLE
Update requirements.txt to fix CVE-2024-49768

### DIFF
--- a/src/edge/requirements.txt
+++ b/src/edge/requirements.txt
@@ -6,5 +6,5 @@ grpcio-tools==1.38.0
 grpcio==1.53.2
 protobuf==3.18.3
 paho-mqtt==1.5.1
-waitress==2.1.2
+waitress==3.0.1
 Flask==2.3.2


### PR DESCRIPTION
Update waitress version from 2.1.2 to 3.0.1 to fix CVE-2024-49768 issue.